### PR TITLE
Try to fix docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,5 +16,6 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/nickrobinson251/PowerFlowData.jl",
+    devbranch="main",
     push_preview=true,
 )


### PR DESCRIPTION
Attempt to fix:
┌ Warning: Possible deploydocs() misconfiguration: main vs master
│ Documenter's configured primary development branch (`devbranch`) is "master", but the
│ current branch (from $GITHUB_REF) is "main". This can happen because Documenter uses
│ GitHub's old default primary branch name as the default value for `devbranch`.
│
│ If your primary development branch is 'main', you must explicitly pass `devbranch = "main"`
│ to deploydocs.
│
│ See #1443 for more discussion: https://github.com/JuliaDocs/Documenter.jl/issues/1443
└ @ Documenter ~/.julia/packages/Documenter/ruzxx/src/deployconfig.jl:398