### PR TITLE
Tidy up some code in parsing.jl

### DIFF
--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -1,7 +1,7 @@
 module PowerFlowData
 
 using DocStringExtensions
-using Parsers: Parsers, Options, xparse
+using Parsers: Parsers, xparse
 using Parsers: codes, eof, invalid, invaliddelimiter, newline, peekbyte
 using Tables
 using WeakRefStrings: InlineString3, InlineString15

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -146,7 +146,7 @@ function parse_row!(rec::Records, row::Int, bytes, pos, len, options, eol_option
     local code::Parsers.ReturnCode
     for col in 1:ncols
         eltyp = eltype(fieldtype(typeof(rec), col))
-        opts = col == ncols ? eol_options : options
+        opts = ifelse(col == ncols, eol_options, options)
         val, pos, code = parse_value(eltyp, bytes, pos, len, opts)
         @inbounds getfield(rec, col)[row] = val
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -79,7 +79,7 @@ function parse_caseid(bytes, pos, len, options)
     return CaseID(ic, sbase), pos
 end
 
-function parse_records!(rec::Records, bytes, pos, len, options, eol_options)
+function parse_records!(rec::R, bytes, pos, len, options, eol_options)::Tuple{R, Int} where {R <: Records}
     nrows = length(getfield(rec, 1))
     nrows == 0 && return rec, pos
     for row in 1:nrows

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -126,17 +126,14 @@ function next_line(bytes, pos, len)
     b = peekbyte(bytes, pos)
     while b !== UInt8('\n') && b !== UInt8('\r')
         pos += 1
-        Parsers.incr!(bytes)  # TODO: not needed if not in Parsers.jl as got Vec{UInt8}?
         eof(bytes, pos, len) && break
         b = peekbyte(bytes, pos)
     end
     # Move forward to be past the `\r` or `\n` byte.
     pos += 1
-    Parsers.incr!(bytes)
     # if line ends `\r\n`, then we're at `\n`and need to move forward again.
     if b === UInt8('\r') && !eof(bytes, pos, len) && peekbyte(bytes, pos) === UInt8('\n')
         pos += 1
-        Parsers.incr!(bytes)
     end
     return pos
 end


### PR DESCRIPTION
Mostly this is to simplify code... it could possibly help parsing time, but `@btime` doesn't say so.
- avoid recreating options (creating `Options` is actually really cheap, but still unnecessary to do it per file to be parsed), and simplify some of the code inside the parsing functions
- annotate `parse_record!` return type because `@code_warntype` seemed to not be able to work it out
