### PR TITLE
Remove EOL options as we can just rely on calling next_line

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -9,14 +9,6 @@ const OPTIONS = Parsers.Options(
     closequotechar='\'',
     delim=',',
 )
-# Change delimiter as way to handle end-of-line comments.
-const EOL_OPTIONS = Parsers.Options(
-    sentinel=missing,
-    quoted=true,
-    openquotechar='\'',
-    closequotechar='\'',
-    delim='/',
-)
 
 getbytes(source::Vector{UInt8}) = source, 1, length(source)
 getbytes(source::IOBuffer) = source.data, source.ptr, source.size
@@ -41,19 +33,19 @@ function parse_network(source)
 
     nrows = count_nrow(bytes, pos, len, OPTIONS)
     @debug "buses" nrows pos
-    buses, pos = parse_records!(Buses(nrows), bytes, pos, len, OPTIONS, EOL_OPTIONS)
+    buses, pos = parse_records!(Buses(nrows), bytes, pos, len, OPTIONS)
 
     nrows = count_nrow(bytes, pos, len, OPTIONS)
     @debug "loads" nrows pos
-    loads, pos = parse_records!(Loads(nrows), bytes, pos, len, OPTIONS, EOL_OPTIONS)
+    loads, pos = parse_records!(Loads(nrows), bytes, pos, len, OPTIONS)
 
     nrows = count_nrow(bytes, pos, len, OPTIONS)
     @debug "gens" nrows pos
-    gens, pos = parse_records!(Generators(nrows), bytes, pos, len, OPTIONS, EOL_OPTIONS)
+    gens, pos = parse_records!(Generators(nrows), bytes, pos, len, OPTIONS)
 
     nrows = count_nrow(bytes, pos, len, OPTIONS)
     @debug "branches" nrows pos
-    branches, pos = parse_records!(Branches(nrows), bytes, pos, len, OPTIONS, EOL_OPTIONS)
+    branches, pos = parse_records!(Branches(nrows), bytes, pos, len, OPTIONS)
 
     return Network(caseid, buses, loads, gens, branches)
 end
@@ -83,11 +75,11 @@ function parse_caseid(bytes, pos, len, options)
     return CaseID(ic, sbase), pos
 end
 
-function parse_records!(rec::R, bytes, pos, len, options, eol_options)::Tuple{R, Int} where {R <: Records}
+function parse_records!(rec::R, bytes, pos, len, options)::Tuple{R, Int} where {R <: Records}
     nrows = length(getfield(rec, 1))
     nrows == 0 && return rec, pos
     for row in 1:nrows
-        pos, code = parse_row!(rec, row, bytes, pos, len, options, eol_options)
+        pos, code = parse_row!(rec, row, bytes, pos, len, options)
 
         # Because we're working around end-of-line comments,
         # rows with comments won't have hit the newline character yet
@@ -142,13 +134,12 @@ function next_line(bytes, pos, len)
     return pos
 end
 
-function parse_row!(rec::Records, row::Int, bytes, pos, len, options, eol_options)
-    ncols = nfields(rec)
+function parse_row!(rec::Records, row::Int, bytes, pos, len, options)
+    ncols = fieldcount(rec)
     local code::Parsers.ReturnCode
     for col in 1:ncols
         eltyp = eltype(fieldtype(typeof(rec), col))
-        opts = ifelse(col == ncols, eol_options, options)
-        val, pos, code = parse_value(eltyp, bytes, pos, len, opts)
+        val, pos, code = parse_value(eltyp, bytes, pos, len, options)
         @inbounds getfield(rec, col)[row] = val
 
         @debug codes(code) row col pos newline=newline(code)


### PR DESCRIPTION
I think we decided we didn't need this, right?