### PR TITLE
Add pretty printing of a `Network` and its fields

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -24,7 +24,7 @@ struct CaseID <: Tables.AbstractRow
     sbase::Float64
 end
 
-CaseID() = CaseID(0, 100.0)
+CaseID(; ic=0, sbase=100.0) = CaseID(ic, sbase)
 
 Tables.columnnames(::CaseID) = fieldnames(CaseID)
 Tables.getcolumn(cid::CaseID, i::Int) = getfield(cid, i)
@@ -407,3 +407,37 @@ struct Network
     "Non-transformer Branch records."
     branches::Branches
 end
+
+###
+### show
+###
+
+function Base.show(io::IO, mime::MIME"text/plain", network::T) where {T <: Network}
+    nfields = fieldcount(T)
+    print(io, "$T with $nfields data categories:\n ")
+    show(io, mime, network.caseid)
+    io_compact = IOContext(io, :compact => true)
+    foreach(2:nfields) do i
+        print(io, "\n ")
+        show(io_compact, mime, getfield(network, i))
+    end
+end
+
+Base.show(io::IO, x::CaseID) = print(io, "CaseID", NamedTuple(x))  # parseable repr
+Base.show(io::IO, ::MIME"text/plain", x::CaseID) = print(io, "CaseID: ", NamedTuple(x))
+
+function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
+    print(io, "$R with $(Tables.rowcount(x)) records")
+    if !get(io, :compact, false)::Bool
+        print(io, ":\n")
+        # show identifiers, e.g. bus numbers, but limit them as there could be very many.
+        _print_identifiers(IOContext(io, :limit => true), x)
+        print(io, "\n")
+        show(io, mime, Tables.schema(R))
+    end
+end
+
+# default to showing the bus numbers, as all records have this column.
+_print_identifiers(io, x::Records) = print(io, " i : ", x.i)
+# show both ends of branches
+_print_identifiers(io, x::Branches) = print(io, " i => j : ", Pair.(x.i, x.j))

--- a/src/types.jl
+++ b/src/types.jl
@@ -433,7 +433,8 @@ function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
         # show identifiers, e.g. bus numbers, but limit them as there could be very many.
         _print_identifiers(IOContext(io, :limit => true), x)
         print(io, "\n")
-        show(io, mime, Tables.schema(R))
+        # Always show all columns, as it's helpful and there are never 100s.
+        show(IOContext(io, :limit => false), mime, Tables.schema(R))
     end
 end
 


### PR DESCRIPTION
We can probably do better than this in time, but i thought i'd put up something to get us started

Tbh, i'm not the biggest fan of pretty printing things, and generally prefer seeing the data over a "helpful"/"compact"/"pretty" summary of the data... but when we've files with millions of lines of data, getting all that data dumped in the REPL isn't great either, so here an attempt at something that might be a helpful for realistic files.  

```julia
julia> net = parse_network("test/testfiles/synthetic_data_v30.raw")
Network with 5 data categories:
 CaseID: (ic = 0, sbase = 100.0)
 Buses with 3 records
 Loads with 2 records
 Generators with 3 records
 Branches with 3 records

julia> net.buses
Buses with 3 records:
 i : [111, 112, 113]
Tables.Schema:
 :i       Vector{Int64} (alias for Array{Int64, 1})
 :name    Vector{WeakRefStrings.String15} (alias for Array{WeakRefStrings.String15, 1})
 :basekv  Vector{Float64} (alias for Array{Float64, 1})
 :ide     Vector{Int64} (alias for Array{Int64, 1})
 :gl      Vector{Float64} (alias for Array{Float64, 1})
 :bl      Vector{Float64} (alias for Array{Float64, 1})
 :area    Vector{Int64} (alias for Array{Int64, 1})
 :zone    Vector{Int64} (alias for Array{Int64, 1})
 :vm      Vector{Float64} (alias for Array{Float64, 1})
 :va      Vector{Float64} (alias for Array{Float64, 1})
 :owner   Vector{Int64} (alias for Array{Int64, 1})

julia> net.branches
Branches with 3 records:
 i => j : [111 => 112, 111 => -113, 112 => 113]
Tables.Schema:
 :i       Vector{Int64} (alias for Array{Int64, 1})
 :j       Vector{Int64} (alias for Array{Int64, 1})
 :ckt     Vector{WeakRefStrings.String3} (alias for Array{WeakRefStrings.String3, 1})
 :r       Vector{Float64} (alias for Array{Float64, 1})
 :x       Vector{Float64} (alias for Array{Float64, 1})
 :b       Vector{Float64} (alias for Array{Float64, 1})
 :rate_a  Vector{Float64} (alias for Array{Float64, 1})
 :rate_b  Vector{Float64} (alias for Array{Float64, 1})
 :rate_c  Vector{Float64} (alias for Array{Float64, 1})
 :gi      Vector{Float64} (alias for Array{Float64, 1})
 :bi      Vector{Float64} (alias for Array{Float64, 1})
 :gj      Vector{Float64} (alias for Array{Float64, 1})
 :bj      Vector{Float64} (alias for Array{Float64, 1})
 :st      Vector{Bool} (alias for Array{Bool, 1})
 :len     Vector{Float64} (alias for Array{Float64, 1})
 :oi      Vector{Int64} (alias for Array{Int64, 1})
 :fi      Vector{Float64} (alias for Array{Float64, 1})
``` 

And we still always have `show(x)` / `show(io, x)` / `repr(x)` for when we do want to just see the data (as we often will when developing the package)
```julia
julia> show(net)
Network(CaseID(ic = 0, sbase = 100.0), Buses([111, 112, 113], WeakRefStrings.String15["STBC      ", "D2JK  ", "7HJG#  "], [161.0, 69.0, 69.0], [1, 1, 1], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [227, 117, 127], [1, 1, 1], [1.09814, 1.04896, 1.02894], [-8.327, -7.247, -4.139], [1, 2, 2]), Loads([111, 113], WeakRefStrings.String3["G1", " G2"], Bool[1, 1], [227, 227], [1.0, 1.0], [-0.004, 0.345], [-0.0, 0.024], [-0.003, 0.711], [-0.0, 0.076], [0.0, -0.028], [-0.0, 0.003], [1, 2]), Generators([111, -112, 113], WeakRefStrings.String3["ST", "PV ", "1"], [0.0, 3.1, 313.01], [0.0, -91.0, 82.29], [110.0, 91.0, 147.0], [0.0, -31.0, -72.0], [1.01375, 1.14634, 1.1233], [334153, 0, 0], [161.0, 175.0, 380.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0], Bool[1, 1, 1], [200.0, 300.0, 55.1], [90.0, 91.0, 229.0], [0.0, 0.0, 0.0], [1, 2, 2], [1.0, 1.0, 1.0]), Branches([111, 111, 112], [112, -113, 113], WeakRefStrings.String3["3 ", "B ", "C "], [0.00187, 0.02938, 0.024915], [0.00442, 0.04547, 0.01926], [0.00227, 0.00094, 0.01019], [322.0, 67.0, 546.0], [322.0, 67.0, 546.0], [322.0, 67.0, 546.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], Bool[1, 1, 1], [0.0, 0.0, 0.0], [1, 1, 1], [1.0, 1.0, 1.0]))
julia> show(net.buses)
Buses([111, 112, 113], WeakRefStrings.String15["STBC      ", "D2JK  ", "7HJG#  "], [161.0, 69.0, 69.0], [1, 1, 1], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [227, 117, 127], [1, 1, 1], [1.09814, 1.04896, 1.02894], [-8.327, -7.247, -4.139], [1, 2, 2])
```
This PR actually also fixes 2-arg `show` for `CaseID` so that the output is valid Julia code, i.e. so the `show` output can be copy-pasted to re-create a similar object.