### PR TITLE
Swap WeakRefStrings.jl -> InlineStrings.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,16 +5,16 @@ version = "1.0.0-DEV"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 DataFrames = "1"
 DocStringExtensions = "0.8.5"
+InlineStrings = "1"
 Parsers = "2"
 Tables = "1"
-WeakRefStrings = "1"
 julia = "1"
 
 [extras]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -91,6 +91,12 @@ git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 version = "0.2.2"
 
+[[InlineStrings]]
+deps = ["Parsers"]
+git-tree-sha1 = "19cb49649f8c41de7fea32d089d37de917b553da"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.0.1"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -167,9 +173,9 @@ version = "1.4.1"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "9d8c00ef7a8d110787ff6f170579846f776133a9"
+git-tree-sha1 = "a8709b968a1ea6abc2dc1967cb1db6ac9a00dfb6"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.4"
+version = "2.0.5"
 
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -182,7 +188,7 @@ uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 version = "1.3.0"
 
 [[PowerFlowData]]
-deps = ["DocStringExtensions", "Parsers", "Tables", "WeakRefStrings"]
+deps = ["DocStringExtensions", "InlineStrings", "Parsers", "Tables"]
 path = ".."
 uuid = "dd99e9e3-7471-40fc-b48d-a10501125371"
 version = "1.0.0-DEV"
@@ -267,12 +273,6 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[WeakRefStrings]]
-deps = ["DataAPI", "Parsers"]
-git-tree-sha1 = "4a4cfb1ae5f26202db4f0320ac9344b3372136b0"
-uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
-version = "1.3.0"
 
 [[Zlib_jll]]
 deps = ["Libdl"]

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -4,7 +4,7 @@ using DocStringExtensions
 using Parsers: Parsers, xparse
 using Parsers: codes, eof, invalid, invaliddelimiter, newline, peekbyte
 using Tables
-using WeakRefStrings: InlineString3, InlineString15
+using InlineStrings: InlineString3, InlineString15
 
 export parse_network
 export Network


### PR DESCRIPTION
Since InlineString is all we used from WeakRefStrings,
we can just use the lighter-weight InlineStrings.jl directly.