### PR TITLE
Change `show` to use PrettyTables; add `length`, `size` for Records

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.0.0-DEV"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -188,16 +188,16 @@ uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 version = "1.3.0"
 
 [[PowerFlowData]]
-deps = ["DocStringExtensions", "InlineStrings", "Parsers", "Tables"]
+deps = ["DocStringExtensions", "InlineStrings", "Parsers", "PrettyTables", "Tables"]
 path = ".."
 uuid = "dd99e9e3-7471-40fc-b48d-a10501125371"
 version = "1.0.0-DEV"
 
 [[PrettyTables]]
 deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
-git-tree-sha1 = "0d1245a357cc61c8cd61934c07447aa569ff22e6"
+git-tree-sha1 = "6330e0c350997f80ed18a9d8d9cb7c7ca4b3a880"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "1.1.0"
+version = "1.2.0"
 
 [[Printf]]
 deps = ["Unicode"]

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -1,10 +1,11 @@
 module PowerFlowData
 
 using DocStringExtensions
+using InlineStrings: InlineString3, InlineString15
 using Parsers: Parsers, xparse
 using Parsers: codes, eof, invalid, invaliddelimiter, newline, peekbyte
+using PrettyTables: pretty_table
 using Tables
-using InlineStrings: InlineString3, InlineString15
 
 export parse_network
 export Network

--- a/src/types.jl
+++ b/src/types.jl
@@ -44,6 +44,8 @@ Tables.columns(x::Records) = x
 Tables.getcolumn(x::Records, i::Int) = getfield(x, i)
 Tables.columnnames(R::Type{<:Records}) = fieldnames(R)
 Tables.schema(x::R) where {R <: Records} = Tables.Schema(fieldnames(R), fieldtypes(R))
+Tables.rowcount(x::Records) = length(x)  # faster than going via `columnnames`
+Base.length(x::Records) = length(getfield(x, 1)::Vector)
 
 """
     $TYPEDEF
@@ -1057,26 +1059,30 @@ function Base.show(io::IO, mime::MIME"text/plain", network::T) where {T <: Netwo
         print(io, "\n ")
         show(io_compact, mime, getfield(network, i))
     end
+    return nothing
 end
 
 Base.show(io::IO, x::CaseID) = print(io, "CaseID", NamedTuple(x))  # parseable repr
 Base.show(io::IO, ::MIME"text/plain", x::CaseID) = print(io, "CaseID: ", NamedTuple(x))
 
-function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
-    print(io, "$R with $(Tables.rowcount(x)) records")
-    if !get(io, :compact, false)::Bool
-        print(io, ":\n")
-        # show identifiers, e.g. bus numbers, but limit them as there could be very many.
-        _print_identifiers(IOContext(io, :limit => true), x)
-        print(io, "\n")
-        # Always show all columns, as it's helpful and there are never 100s.
-        show(IOContext(io, :limit => false, :compact => true), mime, Tables.schema(x))
-    end
-end
+Base.summary(io::IO, x::R) where {R <: Records} = print(io, "$R with $(length(x)) records")
 
-# default to showing the bus numbers, as all records have this column.
-_print_identifiers(io, x::Records) = print(io, " i : ", x.i)
-# show both ends of branches and transformers
-function _print_identifiers(io, x::Union{Branches, Transformers})
-    print(io, " i => j : ", Pair.(x.i, x.j))
+function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
+    if get(io, :compact, false)::Bool
+        Base.summary(io, x)
+    else
+        printstyled(io, R; bold=true)
+        print(io, " with $(length(x)) records,")
+        print(io, " $(length(Tables.columnnames(x))) columns:\n")
+        pretty_table(
+            io, x;
+            compact_printing=true,
+            crop=:both,
+            header=collect(Symbol, Tables.columnnames(x)),
+            newline_at_end=false,
+            vcrop_mode=:middle,  # show first and last rows
+            vlines=Int[],  # no vertical lines
+        )
+    end
+    return nothing
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1051,8 +1051,10 @@ end
 ###
 
 function Base.show(io::IO, mime::MIME"text/plain", network::T) where {T <: Network}
+    show(io, mime, T)
+    get(io, :compact, false)::Bool && return nothing
     nfields = fieldcount(T)
-    print(io, "$T with $nfields data categories:\n ")
+    print(io, " with $nfields data categories:\n ")
     show(io, mime, network.caseid)
     io_compact = IOContext(io, :compact => true)
     foreach(2:nfields) do i

--- a/src/types.jl
+++ b/src/types.jl
@@ -46,6 +46,7 @@ Tables.columnnames(R::Type{<:Records}) = fieldnames(R)
 Tables.schema(x::R) where {R <: Records} = Tables.Schema(fieldnames(R), fieldtypes(R))
 Tables.rowcount(x::Records) = length(x)  # faster than going via `columnnames`
 Base.length(x::Records) = length(getfield(x, 1)::Vector)
+Base.size(x::R) where {R <: Records} = (length(x), fieldcount(R))
 
 """
     $TYPEDEF
@@ -993,6 +994,9 @@ function Tables.columnnames(x::R) where {R <: Transformers}
         fieldnames(R)
     end
 end
+
+# Again, respect the schema.
+Base.size(x::Transformers) = (length(x), length(Tables.columnnames(x)))
 
 ###
 ### Network

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,7 @@ using Test
         @test repr(mime, net.caseid) == "CaseID: (ic = 0, sbase = 100.0)"
 
         @test repr(mime, net.buses; context=(:compact => true)) == "Buses with 3 records"
-        @test startswith(repr(mime, net.buses), "Buses with 3 records:\n i : [111, 112, 113]")
-        @test contains(repr(mime, net.branches), "i => j")  # custom branches "identifier"
-        @test contains(repr(mime, net.transformers), "i => j")
+        @test startswith(repr(mime, net.buses), "Buses with 3 records, 11 columns:\n──")
     end
 
     @testset "v30 file" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ using Test
 
         mime = MIME("text/plain")
         context = :compact => true
+        @test repr(mime, net; context) == "Network"
         @test repr(mime, net) == strip(
             """
             Network with 6 data categories:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,9 @@ using Test
         @test Tables.getcolumn(recs, :x1) == [1, 2, 3]
         @test Tables.getcolumn(recs, 1) == [1, 2, 3]
 
+        @test length(recs) == 3
+        @test size(recs) == (3, 2)
+
         df = DataFrame(recs)
         @test df isa DataFrame
         @test size(df) == (3, 2)
@@ -113,6 +116,8 @@ using Test
         # v30 testfile has both 2-winding and 3-winding data, so should return all columns
         @test length(Tables.columnnames(transformers)) == fieldcount(Transformers)
         @test size(DataFrame(transformers)) == (2, fieldcount(Transformers))
+        @test size(transformers) == (2, fieldcount(Transformers))
+        @test length(transformers) == 2
     end
 
     @testset "v29 file" begin
@@ -162,5 +167,7 @@ using Test
         # v29 testfile has only 2-winding data, so should return only 2-winding columns
         @test length(Tables.columnnames(transformers)) == 35
         @test size(DataFrame(transformers)) == (3, 35)
+        @test size(transformers) == (3, 35)
+        @test length(transformers) == 3
     end
 end


### PR DESCRIPTION
- closes #20 
  - upside is you can inspect the tabular data easliy, without e.g. having to convert it to a DataFrame
   - downside is it adds a dependency, but the upside is worth it, i think...
  - ...maybe in future we can re-assess this if it slows package loading too much or puts people off depending on this package which is currently a hobby project... 
- also "fixed" the compact printing of `Network` (i'm not sure anyone would have noticed, but it's good to follow the rules)
- added `length` as it was helpful for the `show` methods, and added `size` because i think it's good for things to have both 