### PR TITLE
Improve `show` of tables

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -2453,6 +2453,7 @@ function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
         print(io, " $(length(Tables.columnnames(x))) columns:\n")
         pretty_table(
             io, x;
+            alignment_anchor_regex=Dict(0 => [r"\."]), # align floating point numbers
             compact_printing=true,
             crop=:both,
             header=collect(Symbol, Tables.columnnames(x)),

--- a/src/types.jl
+++ b/src/types.jl
@@ -2453,8 +2453,8 @@ function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
         print(io, " $(length(Tables.columnnames(x))) columns:\n")
         pretty_table(
             io, x;
-            alignment_anchor_fallback = :r,
-            alignment_anchor_regex=Dict(0 => [r"\."]), # align floating point numbers
+            alignment_anchor_fallback=:r,  # align right as best for integers
+            alignment_anchor_regex=Dict(0 => [r"\."]),  # align floating point numbers
             compact_printing=true,
             crop=:both,
             header=collect(Symbol, Tables.columnnames(x)),

--- a/src/types.jl
+++ b/src/types.jl
@@ -2453,6 +2453,7 @@ function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
         print(io, " $(length(Tables.columnnames(x))) columns:\n")
         pretty_table(
             io, x;
+            alignment_anchor_fallback = :r,
             alignment_anchor_regex=Dict(0 => [r"\."]), # align floating point numbers
             compact_printing=true,
             crop=:both,

--- a/src/types.jl
+++ b/src/types.jl
@@ -2445,7 +2445,7 @@ end
 Base.summary(io::IO, x::R) where {R <: Records} = print(io, "$R with $(length(x)) records")
 
 function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
-    if get(io, :compact, false)::Bool
+    if get(io, :compact, false)::Bool || isempty(x)
         Base.summary(io, x)
     else
         printstyled(io, R; bold=true)


### PR DESCRIPTION
Before (on `main`):
```jl
julia> net.multi_terminal_dc
MultiTerminalDCLines with 0 records, 1 columns:


julia> net.generators
Generators with 3 records, 20 columns:
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    i   id      pg     qg     qt     qb       vs    ireg  mbase   zr   zx   rt   xt  gtap  stat  rmpct     pt   pb  oi   fi
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  111   ST     0.0    0.0  110.0    0.0  1.01375  334153  161.0  0.0  1.0  0.0  0.0   1.0  true  200.0   90.0  0.0   1  1.0
 -112  PV      3.1  -91.0   91.0  -31.0  1.14634       0  175.0  0.0  1.0  0.0  0.0   1.0  true  300.0   91.0  0.0   2  1.0
  113    1  313.01  82.29  147.0  -72.0   1.1233       0  380.0  0.0  1.0  0.0  0.0   1.0  true   55.1  229.0  0.0   2  1.0
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```
After (this PR):
```jl
julia> net.multi_terminal_dc
MultiTerminalDCLines with 0 records

julia> net.generators
Generators with 3 records, 20 columns:
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    i   id      pg      qg     qt     qb       vs    ireg  mbase   zr   zx   rt   xt  gtap  stat  rmpct     pt   pb  oi   fi
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  111   ST    0.0     0.0   110.0    0.0  1.01375  334153  161.0  0.0  1.0  0.0  0.0   1.0  true  200.0   90.0  0.0   1  1.0
 -112  PV     3.1   -91.0    91.0  -31.0  1.14634       0  175.0  0.0  1.0  0.0  0.0   1.0  true  300.0   91.0  0.0   2  1.0
  113    1  313.01   82.29  147.0  -72.0  1.1233        0  380.0  0.0  1.0  0.0  0.0   1.0  true   55.1  229.0  0.0   2  1.0
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```