### PR TITLE
When printing table, leave prompt and summary visible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerFlowData"
 uuid = "dd99e9e3-7471-40fc-b48d-a10501125371"
 authors = "Nick Robinson <npr251@gmail.com> and contributors"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/types.jl
+++ b/src/types.jl
@@ -2911,12 +2911,14 @@ function Base.show(io::IO, mime::MIME"text/plain", x::R) where {R <: Records}
         printstyled(io, R_str; bold=true)
         print(io, " with $(length(x)) records,")
         print(io, " $(length(Tables.columnnames(x))) columns:\n")
+        (vsize, hsize) = displaysize(io)
         pretty_table(
             io, x;
             alignment_anchor_fallback=:r,  # align right as best for integers
             alignment_anchor_regex=Dict(0 => [r"\."]),  # align floating point numbers
             compact_printing=true,
             crop=:both,
+            display_size=(max(1, vsize-3), hsize), # save some vertical space for summary
             header=collect(Symbol, Tables.columnnames(x)),
             newline_at_end=false,
             vcrop_mode=:middle,  # show first and last rows


### PR DESCRIPTION
When inspecting a table in the REPL, i think it is better to leave the summary visible so we don't have to scroll up at all

Now we get output like:
<img width="1078" alt="Screenshot 2021-11-17 at 16 53 17" src="https://user-images.githubusercontent.com/13448787/142245686-2cce8c7f-a749-405f-9d77-d8b681bcab73.png">

Whereas the same command on `main` gives:
<img width="1078" alt="Screenshot 2021-11-17 at 16 53 40" src="https://user-images.githubusercontent.com/13448787/142245778-5738f4a8-64ed-42ec-b2c1-b34917b4303c.png">
