### PR TITLE
Simplify code for `IDRow`s; build Vector not NamedTuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerFlowData"
 uuid = "dd99e9e3-7471-40fc-b48d-a10501125371"
 authors = "Nick Robinson <npr251@gmail.com> and contributors"
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -3,7 +3,7 @@ module PowerFlowData
 using DocStringExtensions
 using InlineStrings: InlineString1, InlineString3, InlineString15
 using Parsers: Parsers, xparse
-using Parsers: codes, eof, invalid, invaliddelimiter, newline, peekbyte
+using Parsers: codes, eof, invalid, invaliddelimiter, newline, valueok, peekbyte
 using PrettyTables: pretty_table
 using Tables
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -408,18 +408,18 @@ end
 @generated function parse_idrow(::Type{R}, bytes, pos, len, options) where {R <: IDRow}
     block = Expr(:block)
     nfields = fieldcount(R)
+    T = nonmissingtype(fieldtype(R, 1))
     push!(block.args, quote
         args = Any[]
-        code = Parsers.OK
+        (pos, code) = parse_value!(args, $T, bytes, pos, len, options)
     end)
-    for i in 1:nfields
+    for i in 2:nfields
         T = nonmissingtype(fieldtype(R, i))
         push!(block.args, quote
             if invalid(code) || newline(code)
                 push!(args, missing)
             else
-                pos, code = parse_value!(args, $T, bytes, pos, len, options)
-                @debug 1 "$pos:  $(Parsers.codes(code))"
+                (pos, code) = parse_value!(args, $T, bytes, pos, len, options)
             end
         end)
     end


### PR DESCRIPTION
The current code for created `IDRow` types is probably overly complex, and the repeated merging of NamedTuples causes an issue for inference, so this refactors that code... 

~but right now it seems to slow things down a touch overall~ actually timing parsing it seems no different and `@snoopi_deep` suggests it's a tiny bit easier on inference:

before:
```jl
julia> using SnoopCompile, PowerFlowData

julia> tinf = @snoopi_deep parse_network("raw/realistic29.raw")
InferenceTimingNode: 7.191346/10.095295 on Core.Compiler.Timings.ROOT() with 109 direct children
```
now:
```jl
julia> using SnoopCompile, PowerFlowData

julia> tinf = @snoopi_deep parse_network("raw/realistic29.raw")
InferenceTimingNode: 6.932281/9.740314 on Core.Compiler.Timings.ROOT() with 107 direct children
```