### PR TITLE
Implement isempty for Network

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerFlowData"
 uuid = "dd99e9e3-7471-40fc-b48d-a10501125371"
 authors = "Nick Robinson <npr251@gmail.com> and contributors"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/types.jl
+++ b/src/types.jl
@@ -2846,6 +2846,15 @@ for R in (
     @eval $R(sizehint::Integer=0) = $R(map(T -> sizehint!(T(), sizehint), fieldtypes($R))...)::$R
 end
 
+function Base.isempty(net::T) where {T <: Network}
+    for i in 1:fieldcount(T)
+        if typeof(getfield(net, i)) <: Records && !isempty(getfield(net, i))
+            return false
+        end
+    end
+    return true
+end
+
 ###
 ### show
 ###

--- a/src/types.jl
+++ b/src/types.jl
@@ -2848,7 +2848,7 @@ end
 
 function Base.isempty(net::T) where {T <: Network}
     for i in 1:fieldcount(T)
-        if typeof(getfield(net, i)) <: Records && !isempty(getfield(net, i))
+        if fieldtype(T, i) <: Records && !isempty(getfield(net, i))
             return false
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -467,7 +467,7 @@ using Test
             CaseID(),
             Buses30(),
             Loads(),
-            FixedShunts(),
+            nothing,
             Generators(),
             Branches30(),
             Transformers(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -459,4 +459,31 @@ using Test
         @test length(net.buses) == 2
         @test length(net.loads) == 1
     end
+
+    @testset "empty network" begin
+
+        empty_net = Network(
+            30,
+            CaseID(),
+            Buses30(),
+            Loads(),
+            FixedShunts(),
+            Generators(),
+            Branches30(),
+            Transformers(),
+            AreaInterchanges(),
+            TwoTerminalDCLines30(),
+            VSCDCLines(),
+            SwitchedShunts30(),
+            ImpedanceCorrections(),
+            MultiTerminalDCLines(),
+            MultiSectionLineGroups30(),
+            Zones(),
+            InterAreaTransfers(),
+            Owners(),
+            FACTSDevices30(),
+        )
+
+        @test isempty(empty_net)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -484,6 +484,9 @@ using Test
             FACTSDevices30(),
         )
 
+        full_net = parse_network("testfiles/synthetic_data_v30.raw")
+
         @test isempty(empty_net)
+        @test !isempty(full_net)
     end
 end


### PR DESCRIPTION
The definition I've implemented is that a `Network` is empty if all its `Records` fields are empty.  